### PR TITLE
Upstream support + example

### DIFF
--- a/aiofcm/client.py
+++ b/aiofcm/client.py
@@ -7,14 +7,14 @@ from aiofcm.logging import logger
 
 
 class FCM:
-    def __init__(self, sender_id, api_key, callback=None,
+    def __init__(self, sender_id, api_key, upstream_callback=None,
                  min_connections=None, max_connections=10, loop=None):
         if min_connections is None:
-            min_connections = 1 if callback else 0
+            min_connections = 1 if upstream_callback else 0
 
         # type: (int, str, callback, int int,
         #        Optional[asyncio.AbstractEventLoop]) -> NoReturn
-        self.pool = FCMConnectionPool(sender_id, api_key, callback,
+        self.pool = FCMConnectionPool(sender_id, api_key, upstream_callback,
                                       min_connections, max_connections, loop)
 
     async def send_message(self, message: Message) -> MessageResponse:

--- a/aiofcm/client.py
+++ b/aiofcm/client.py
@@ -7,12 +7,15 @@ from aiofcm.logging import logger
 
 
 class FCM:
-    def __init__(self, sender_id, api_key, callback=None, min_connections=None, max_connections=10, loop=None):
+    def __init__(self, sender_id, api_key, callback=None,
+                 min_connections=None, max_connections=10, loop=None):
         if min_connections is None:
             min_connections = 1 if callback else 0
 
-        # type: (int, str, int, Optional[asyncio.AbstractEventLoop]) -> NoReturn
-        self.pool = FCMConnectionPool(sender_id, api_key, callback, min_connections, max_connections, loop)
+        # type: (int, str, callback, int int,
+        #        Optional[asyncio.AbstractEventLoop]) -> NoReturn
+        self.pool = FCMConnectionPool(sender_id, api_key, callback,
+                                      min_connections, max_connections, loop)
 
     async def send_message(self, message: Message) -> MessageResponse:
         response = await self.pool.send_message(message)

--- a/aiofcm/client.py
+++ b/aiofcm/client.py
@@ -7,9 +7,12 @@ from aiofcm.logging import logger
 
 
 class FCM:
-    def __init__(self, sender_id, api_key, max_connections=10, loop=None):
+    def __init__(self, sender_id, api_key, callback=None, min_connections=None, max_connections=10, loop=None):
+        if min_connections is None:
+            min_connections = 1 if callback else 0
+
         # type: (int, str, int, Optional[asyncio.AbstractEventLoop]) -> NoReturn
-        self.pool = FCMConnectionPool(sender_id, api_key, max_connections, loop)
+        self.pool = FCMConnectionPool(sender_id, api_key, callback, min_connections, max_connections, loop)
 
     async def send_message(self, message: Message) -> MessageResponse:
         response = await self.pool.send_message(message)

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -30,7 +30,8 @@ class FCMXMPPConnection:
     FCM_PORT = 5235
     INACTIVITY_TIME = 10
 
-    def __init__(self, sender_id, api_key, loop=None, max_requests=1000):
+    def __init__(self, sender_id, api_key, callback=None, loop=None, max_requests=1000):
+        self.callback = callback
         self.max_requests = max_requests
         self.xmpp_client = self._create_client(sender_id, api_key, loop)
         self.loop = loop
@@ -97,11 +98,25 @@ class FCMXMPPConnection:
 
         body = json.loads(message.fcm_payload.text)
 
+        handle_upstream = False
         try:
             message_id = body['message_id']
             message_type = body['message_type']
         except KeyError:
-            logger.warning('Got strange response: %s', body)
+            try:
+                message_id = body['message_id']
+                category = body['category']
+                device_token = body['from']
+                data = body['data']
+                handle_upstream = True
+            except KeyError:
+                logger.warning('Got strange response: %s', body)
+                return
+
+        if handle_upstream:
+            asyncio.ensure_future(self.send_ack(device_token, message_id))
+            if self.callback is not None:
+                asyncio.ensure_future(self.callback(device_token, category, data))
             return
 
         if message_type not in (FCMMessageType.ACK, FCMMessageType.NACK):
@@ -138,6 +153,7 @@ class FCMXMPPConnection:
         self.requests[message.message_id] = future_response
 
         self.refresh_inactivity_timer()
+
         try:
             await self.xmpp_client.stream.send(msg)
         except Exception:
@@ -146,6 +162,27 @@ class FCMXMPPConnection:
 
         response = await future_response
         return response
+
+    async def send_ack(self, device_token, message_id):
+        if not self.connected:
+            await self.connect()
+        msg = aioxmpp.Message(
+            type_=aioxmpp.MessageType.NORMAL
+        )
+        payload = FCMMessage()
+
+        payload_body = {"to":str(device_token), "message_id":str(message_id), "message_type":"ack"}
+
+        payload.text = json.dumps(payload_body)
+        msg.fcm_payload = payload
+
+        self.refresh_inactivity_timer()
+
+        try:
+            await self.xmpp_client.stream.send(msg)
+        except Exception:
+            self.requests.pop(message.message_id)
+            raise
 
     def refresh_inactivity_timer(self):
         if self.inactivity_timer:
@@ -161,10 +198,13 @@ class FCMXMPPConnection:
 class FCMConnectionPool:
     MAX_ATTEMPTS = 10
 
-    def __init__(self, sender_id, api_key, max_connections=10, loop=None):
+    def __init__(self, sender_id, api_key, callback=None, min_connections=0, max_connections=10, loop=None):
         # type: (int, str, int, Optional[asyncio.AbstractEventLoop]) -> NoReturn
         self.sender_id = sender_id
         self.api_key = api_key
+        self.callback = callback
+        assert min_connections <= max_connections, "min_connections is greater than max_connections"
+        self.min_connections = min_connections
         self.max_connections = max_connections
         self.loop = loop or asyncio.get_event_loop()
         self.connections = []
@@ -172,10 +212,13 @@ class FCMConnectionPool:
 
         self.loop.set_exception_handler(self.__exception_handler)
 
+        asyncio.ensure_future(self.maintain_min_connections_open())
+
     async def connect(self) -> FCMXMPPConnection:
         connection = FCMXMPPConnection(
             sender_id=self.sender_id,
             api_key=self.api_key,
+            callback=self.callback,
             loop=self.loop,
         )
         await connection.connect()
@@ -246,6 +289,19 @@ class FCMConnectionPool:
             except Exception as e:
                 logger.error('Could not send message %s: %s',
                              message.message_id, e)
+
+    async def maintain_min_connections_open(self):
+        while True:
+            missing_connections = max(0, self.min_connections - len(self.connections))
+            if missing_connections > 0:
+                logger.debug('Creating %d missing connections' % missing_connections)
+                for _ in range(missing_connections):
+                    asyncio.ensure_future(self.acquire())
+
+            await asyncio.sleep(1)
+
+            for connection in self.connections[-missing_connections:]:
+                connection.refresh_inactivity_timer()
 
     @staticmethod
     def __exception_handler(_, context):

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -207,7 +207,8 @@ class FCMConnectionPool:
         self.sender_id = sender_id
         self.api_key = api_key
         self.callback = callback
-        assert min_connections <= max_connections, "min_connections is greater than max_connections"
+        if min_connections > max_connections:
+            raise ValueError("min_connections is greater than max_connections")
         self.min_connections = min_connections
         self.max_connections = max_connections
         self.loop = loop or asyncio.get_event_loop()

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -180,11 +180,7 @@ class FCMXMPPConnection:
         msg.fcm_payload = payload
 
         self.refresh_inactivity_timer()
-        try:
-            await self.xmpp_client.stream.send(msg)
-        except Exception:
-            self.requests.pop(message.message_id)
-            raise
+        await self.xmpp_client.stream.send(msg)
 
     def refresh_inactivity_timer(self):
         if self.inactivity_timer:

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -153,7 +153,6 @@ class FCMXMPPConnection:
         self.requests[message.message_id] = future_response
 
         self.refresh_inactivity_timer()
-
         try:
             await self.xmpp_client.stream.send(msg)
         except Exception:
@@ -177,7 +176,6 @@ class FCMXMPPConnection:
         msg.fcm_payload = payload
 
         self.refresh_inactivity_timer()
-
         try:
             await self.xmpp_client.stream.send(msg)
         except Exception:

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -300,8 +300,8 @@ class FCMConnectionPool:
             missing_connections = max(0, self.min_connections
                                       - len(self.connections))
             if missing_connections > 0:
-                logger.debug('Creating %d missing connections'
-                             % missing_connections)
+                logger.debug('Creating %d missing connections',
+                             missing_connections)
                 for _ in range(missing_connections):
                     asyncio.ensure_future(self.acquire())
 

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -213,7 +213,10 @@ class FCMConnectionPool:
 
         self.loop.set_exception_handler(self.__exception_handler)
 
-        self.maintain_connections_task = asyncio.ensure_future(self.maintain_min_connections_open())
+        if min_connections == 0:
+            self.maintain_connections_task = None
+        else:
+            self.maintain_connections_task = asyncio.ensure_future(self.maintain_min_connections_open())
 
     async def connect(self) -> FCMXMPPConnection:
         connection = FCMXMPPConnection(

--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -30,7 +30,8 @@ class FCMXMPPConnection:
     FCM_PORT = 5235
     INACTIVITY_TIME = 10
 
-    def __init__(self, sender_id, api_key, callback=None, loop=None, max_requests=1000):
+    def __init__(self, sender_id, api_key, callback=None, loop=None,
+                 max_requests=1000):
         self.callback = callback
         self.max_requests = max_requests
         self.xmpp_client = self._create_client(sender_id, api_key, loop)
@@ -116,7 +117,8 @@ class FCMXMPPConnection:
         if handle_upstream:
             asyncio.ensure_future(self.send_ack(device_token, message_id))
             if self.callback is not None:
-                asyncio.ensure_future(self.callback(device_token, category, data))
+                asyncio.ensure_future(self.callback(device_token,
+                                                    category, data))
             return
 
         if message_type not in (FCMMessageType.ACK, FCMMessageType.NACK):
@@ -170,7 +172,9 @@ class FCMXMPPConnection:
         )
         payload = FCMMessage()
 
-        payload_body = {"to":str(device_token), "message_id":str(message_id), "message_type":"ack"}
+        payload_body = {"to": str(device_token),
+                        "message_id": str(message_id),
+                        "message_type": "ack"}
 
         payload.text = json.dumps(payload_body)
         msg.fcm_payload = payload
@@ -196,8 +200,10 @@ class FCMXMPPConnection:
 class FCMConnectionPool:
     MAX_ATTEMPTS = 10
 
-    def __init__(self, sender_id, api_key, callback=None, min_connections=0, max_connections=10, loop=None):
-        # type: (int, str, int, Optional[asyncio.AbstractEventLoop]) -> NoReturn
+    def __init__(self, sender_id, api_key, callback=None, min_connections=0,
+                 max_connections=10, loop=None):
+        # type: (int, str, callback, int, int,
+        #        Optional[asyncio.AbstractEventLoop]) -> NoReturn
         self.sender_id = sender_id
         self.api_key = api_key
         self.callback = callback
@@ -290,9 +296,11 @@ class FCMConnectionPool:
 
     async def maintain_min_connections_open(self):
         while True:
-            missing_connections = max(0, self.min_connections - len(self.connections))
+            missing_connections = max(0, self.min_connections
+                                      - len(self.connections))
             if missing_connections > 0:
-                logger.debug('Creating %d missing connections' % missing_connections)
+                logger.debug('Creating %d missing connections'
+                             % missing_connections)
                 for _ in range(missing_connections):
                     asyncio.ensure_future(self.acquire())
 

--- a/examples/upstream.py
+++ b/examples/upstream.py
@@ -7,7 +7,7 @@ from aiofcm import FCM, Message, PRIORITY_HIGH
 
 # Send and receive firebase messages from cloud to device
 # This example:
-# 1. Sends a timestamp every 30 seconds to a subscribed device
+# 1. Sends a timestamp every 5 seconds to a subscribed device
 # 2. Echo back an uppercase of the 'txt' field in the data
 
 

--- a/examples/upstream.py
+++ b/examples/upstream.py
@@ -11,8 +11,8 @@ from aiofcm import FCM, Message, PRIORITY_HIGH
 # 2. Echo back an uppercase of the 'txt' field in the data
 
 
-API_KEY = ... #String
-SENDER_ID = ... #Integer
+API_KEY = ...    # String
+SENDER_ID = ...  # Integer
 
 DEVICE_TOKEN = None
 
@@ -25,14 +25,14 @@ async def my_callback(device_token, app_name, data):
     print("=======================")
 
     txt = data['txt']
-    txt = txt.upper() #Echo back uppercase txt field
+    txt = txt.upper()  # Echo back uppercase txt field
 
     message = Message(
         device_token=device_token,
-        data={"txt":txt},
-        message_id=str(uuid4()), # optional
-        time_to_live=0,          # optional
-        priority=PRIORITY_HIGH,  # optional
+        data={"txt": txt},
+        message_id=str(uuid4()),  # optional
+        time_to_live=0,           # optional
+        priority=PRIORITY_HIGH,   # optional
     )
 
     await fcm.send_message(message)
@@ -52,8 +52,8 @@ async def run():
 
             message = Message(
                 device_token=DEVICE_TOKEN,
-                data={"txt":txt},
-                message_id=str(uuid4()), # optional
+                data={"txt": txt},
+                message_id=str(uuid4()),  # optional
                 time_to_live=0,          # optional
                 priority=PRIORITY_HIGH,  # optional
             )

--- a/examples/upstream.py
+++ b/examples/upstream.py
@@ -63,7 +63,7 @@ async def run():
         await asyncio.sleep(5)
 
 
-fcm = FCM(SENDER_ID, API_KEY, callback=my_callback)
+fcm = FCM(SENDER_ID, API_KEY, upstream_callback=my_callback)
 loop = asyncio.get_event_loop()
 asyncio.ensure_future(run())
 loop.run_forever()

--- a/examples/upstream.py
+++ b/examples/upstream.py
@@ -1,0 +1,69 @@
+import datetime
+import time
+import sys
+import asyncio
+from uuid import uuid4
+from aiofcm import FCM, Message, PRIORITY_HIGH
+
+# Send and receive firebase messages from cloud to device
+# This example:
+# 1. Sends a timestamp every 30 seconds to a subscribed device
+# 2. Echo back an uppercase of the 'txt' field in the data
+
+
+API_KEY = ... #String
+SENDER_ID = ... #Integer
+
+DEVICE_TOKEN = None
+
+
+async def my_callback(device_token, app_name, data):
+    global DEVICE_TOKEN
+
+    print("=======================")
+    print("Received:", data)
+    print("=======================")
+
+    txt = data['txt']
+    txt = txt.upper() #Echo back uppercase txt field
+
+    message = Message(
+        device_token=device_token,
+        data={"txt":txt},
+        message_id=str(uuid4()), # optional
+        time_to_live=0,          # optional
+        priority=PRIORITY_HIGH,  # optional
+    )
+
+    await fcm.send_message(message)
+
+    if txt == "subscribe".upper():
+        DEVICE_TOKEN = device_token
+        print("set DEVICE_TOKEN to", device_token)
+    elif txt == "unsubscribe".upper():
+        DEVICE_TOKEN = None
+        print("unset DEVICE_TOKEN")
+
+
+async def run():
+    while True:
+        if DEVICE_TOKEN is not None:
+            txt = datetime.datetime.now().strftime("%H:%M:%S")
+
+            message = Message(
+                device_token=DEVICE_TOKEN,
+                data={"txt":txt},
+                message_id=str(uuid4()), # optional
+                time_to_live=0,          # optional
+                priority=PRIORITY_HIGH,  # optional
+            )
+
+            print(time.time(), "Send:", txt)
+            await fcm.send_message(message)
+        await asyncio.sleep(5)
+
+
+fcm = FCM(SENDER_ID, API_KEY, callback=my_callback)
+loop = asyncio.get_event_loop()
+asyncio.ensure_future(run())
+loop.run_forever()


### PR DESCRIPTION
Added upstream support: https://firebase.google.com/docs/cloud-messaging/receive-upstream

* Allow to register a callback for handling upstream messages.
* If a callback is registered, the pool will automatically open and maintain an XMPP connection.
* Added a usage example: examples/upstream.py