### PR TITLE
Do not pass "loop" parameter to asyncio.Lock() on Python 3.10+

### DIFF
--- a/aiofcm/connection.py
+++ b/aiofcm/connection.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import asyncio
 from typing import Optional, NoReturn
@@ -168,7 +169,11 @@ class FCMConnectionPool:
         self.max_connections = max_connections
         self.loop = loop or asyncio.get_event_loop()
         self.connections = []
-        self._lock = asyncio.Lock(loop=self.loop)
+        # Python 3.10+ does not use the "loop" parameter
+        if sys.hexversion >= 0x030A00F0:
+            self._lock = asyncio.Lock()
+        else:
+            self._lock = asyncio.Lock(loop=self.loop)
 
         self.loop.set_exception_handler(self.__exception_handler)
 


### PR DESCRIPTION
From Python 3.10 and up, when `asyncio.Lock()` is called with the `loop` parameter, an exception is raised:

```TypeError: As of 3.10, the *loop* parameter was removed from Lock() since it is no longer necessary"```