### PR TITLE
add max_connection_attempts option to prevent infinitely retrying

### DIFF
--- a/aiofcm/__init__.py
+++ b/aiofcm/__init__.py
@@ -1,5 +1,5 @@
 from aiofcm.client import FCM
 from aiofcm.common import Message, PRIORITY_NORMAL, PRIORITY_HIGH
+from aiofcm.exceptions import ConnectionError
 
-
-__all__ = ['FCM', 'Message', 'PRIORITY_NORMAL', 'PRIORITY_HIGH']
+__all__ = ['FCM', 'Message', 'PRIORITY_NORMAL', 'PRIORITY_HIGH', 'ConnectionError']

--- a/aiofcm/client.py
+++ b/aiofcm/client.py
@@ -7,8 +7,14 @@ from aiofcm.logging import logger
 
 
 class FCM:
-    def __init__(self, sender_id, api_key, max_connections=10, max_max_connection_attempts=None, loop=None):
-        # type: (int, str, int, Optional[int], Optional[asyncio.AbstractEventLoop]) -> NoReturn
+    def __init__(
+        self,
+        sender_id: int,
+        api_key: str,
+        max_connections: int = 10,
+        max_connection_attempts: Optional[int] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ):
         self.pool = FCMConnectionPool(sender_id, api_key, max_connections, max_connection_attempts, loop)
 
     async def send_message(self, message: Message) -> MessageResponse:

--- a/aiofcm/client.py
+++ b/aiofcm/client.py
@@ -7,9 +7,9 @@ from aiofcm.logging import logger
 
 
 class FCM:
-    def __init__(self, sender_id, api_key, max_connections=10, loop=None):
-        # type: (int, str, int, Optional[asyncio.AbstractEventLoop]) -> NoReturn
-        self.pool = FCMConnectionPool(sender_id, api_key, max_connections, loop)
+    def __init__(self, sender_id, api_key, max_connections=10, max_max_connection_attempts=None, loop=None):
+        # type: (int, str, int, Optional[int], Optional[asyncio.AbstractEventLoop]) -> NoReturn
+        self.pool = FCMConnectionPool(sender_id, api_key, max_connections, max_connection_attempts, loop)
 
     async def send_message(self, message: Message) -> MessageResponse:
         response = await self.pool.send_message(message)

--- a/aiofcm/exceptions.py
+++ b/aiofcm/exceptions.py
@@ -3,3 +3,8 @@ class ConnectionClosed(Exception):
 
     def __str__(self):
         return 'Connection closed'
+
+
+class ConnectionError(Exception):
+    def __str__(self):
+        return 'Failed to connect'


### PR DESCRIPTION
Hello. I had a problem that aiofcm is retrying infinitely when creating connection was failed (ex. due to invalid api_key, etc..)

I found https://github.com/Fatal1ty/aiofcm/issues/8 this issue, so i added `max_connection_attempts` option similar with https://github.com/Fatal1ty/aioapns/pull/11.

Thank you in advance.